### PR TITLE
add abs() call to refclock offset check

### DIFF
--- a/check_meinberg_lantime_ntp.pl
+++ b/check_meinberg_lantime_ntp.pl
@@ -172,7 +172,7 @@ sub check
         'Stratum: ' . $stratum,
     );
 
-    my $refclock_offset = $result->{$mbgLtNgNtpRefclockOffset};
+    my $refclock_offset = abs($result->{$mbgLtNgNtpRefclockOffset});
     my $refclock_offset_threshold = Monitoring::Plugin::Threshold->set_thresholds(
         warning  => $mp->opts->get('refclock-offset-warning'),
         critical => $mp->opts->get('refclock-offset-critical'),


### PR DESCRIPTION
This should fix an issue where the reference clock offset being a negative value will cause it to fall outside the warning/critical thresholds and generate an alert.